### PR TITLE
M_state and interpret implemented

### DIFF
--- a/M_state.scm
+++ b/M_state.scm
@@ -10,9 +10,13 @@
            (state-set (dec-var statement) (M_value (dec-value statement) state) (state-declare (dec-var statement) state)))) ; declaration with assignment
       ((eq? (statement-type statement) '=) (state-set (dec-var statement) (M_value (dec-value statement) state) state)) ; assignment
       ((eq? (statement-type statement) 'if) ; "if" statement
-       (if (eq? (M_value (condition statement) state) 'true)
-           (M_state (st-then statement) state) ; condition was true
-           (M_state (st-else statement) state))) ; condition was false
+       (if (eq? (length statement) 3)
+           (if (eq? (M_value (condition statement) state) 'true) ; statement without "else" clause
+               (M_state (st-then statement) state) ; condition was true
+               state) ; condition was false (then we just return the state since there is no "else" clause)
+           (if (eq? (M_value (condition statement) state) 'true) ; statement with "else" clause
+               (M_state (st-then statement) state) ; condition was true
+               (M_state (st-else statement) state)))) ; condition was false
       ((eq? (statement-type statement) 'while) ; "while" statement
        (if (eq? (M_value (condition statement) state) 'true)
            (M_state statement (M_state (while-body statement) state)) ; condition was true
@@ -24,7 +28,7 @@
     (cond
       ((number? l) l) ; input is a number
       ((eq? l 'true) 'true) ; input is the boolean value true
-      ((eq? l 'true) 'false) ; input is the boolean value false
+      ((eq? l 'false) 'false) ; input is the boolean value false
       ((symbol? l) (state-get l state)) ; input is a variable
       ; espressions
       ((eq? (operator l) '+) (mv-operate l state +))
@@ -41,6 +45,7 @@
       ((eq? (operator l) '>=) (mb-compare l state >=))
       ((eq? (operator l) '<)  (mb-compare l state <))
       ((eq? (operator l) '<=) (mb-compare l state <=))
+      ((eq? (operator l) '!=) (mb-compare l state !=))
       ; logical operations
       ((eq? (operator l) '&&) (mb-and l state))
       ((eq? (operator l) '||) (mb-or l state))
@@ -84,6 +89,10 @@
     (if (func (M_value (operand1 l) state) (M_value (operand2 l) state))
         'true
         'false)))
+
+(define !=
+  (lambda (a1 a2)
+    (not (= a1 a2))))
 
 ; functions for boolean "and", "or", and "not"
 (define mb-and

--- a/M_state.scm
+++ b/M_state.scm
@@ -16,7 +16,8 @@
       ((eq? (statement-type statement) 'while) ; "while" statement
        (if (eq? (M_value (condition statement) state) 'true)
            (M_state statement (M_state (while-body statement) state)) ; condition was true
-           state))))) ; condition was false
+           state)) ; condition was false
+      ((eq? (statement-type statement) 'return) (state-add-return (M_value (return-val statement) state) state))))) ; "return" statement
 
 (define M_value
   (lambda (l state)
@@ -46,9 +47,10 @@
       ((eq? (operator l) '!) (mb-not l state)))))
 
 ; macros for statements
-(define statement-type car)
+(define statement-type car) ; the type of statement (e.g. "if", "=", "return", ...)
 (define dec-var cadr) ; the variable being assigned to in an assignment or declaration
 (define dec-value caddr) ; the value being assigned in an assignment or declaration
+(define return-val cadr) ; the value being returned in a "return" statement
 (define condition cadr) ; the boolean condition being evaluated in an "if" or "else" statement
 (define st-then caddr) ; the "then" statement in an "if"
 (define st-else cadddr) ; the "else" statement in an "if"

--- a/M_state.scm
+++ b/M_state.scm
@@ -8,27 +8,19 @@
 (define M_value
   (lambda (l state)
     (cond
-      ((null? l) (error "Tried to get the value of null."))
       ((number? l) l) ; input is a number
+      ((eq? l 'true) 'true) ; input is the boolean value true
+      ((eq? l 'true) 'false) ; input is the boolean value false
       ((symbol? l) (state-get l state)) ; input is a variable
-      ((not (pair? l)) (error "M_value is only defined for numbers, variables, expressions, and assignments."))
-      ; else it is an expression or an assignment
+      ; espressions
       ((eq? (operator l) '+) (mv-operate l state +))
       ((eq? (operator l) '-) (mv-operate l state -))
       ((eq? (operator l) '*) (mv-operate l state *))
       ((eq? (operator l) '/) (mv-operate l state quotient))
       ((eq? (operator l) '%) (mv-operate l state remainder))
+      ; assignment or declaration with assignment
       ((eq? (operator l) '=) (M_value (dec-value l) state)) ; the value of an assignment is the value being assigned
       ((and (eq? (operator l) 'var) (has-value? l)) (M_value (dec-value l) state)) ; declaration must include assignment
-      (else (error "M_value is only defined for numbers, variables, expressions, and assignments.")))))
-
-(define M_boolean
-  (lambda (l state)
-    (cond
-      ((null? l) (error "Tried to get the boolean value of null"))
-      ((eq? l 'true) 'true) ; true is true
-      ((eq? l 'false) 'false) ; false is false
-      ((not (pair? l)) (error "M_boolean is only defined for 'true, 'false, comparisons, and logical operators."))
       ; types of comparison
       ((eq? (operator l) '==) (mb-compare l state =))
       ((eq? (operator l) '>)  (mb-compare l state >))
@@ -38,8 +30,7 @@
       ; logical operations
       ((eq? (operator l) '&&) (mb-and l state))
       ((eq? (operator l) '||) (mb-or l state))
-      ((eq? (operator l) '!) (mb-not l state))
-      (else (error "M_boolean is only defined for 'true, 'false, comparisons, and logical operators."))))) 
+      ((eq? (operator l) '!) (mb-not l state)))))
 
 ; prefix notation
 (define operator car)
@@ -76,19 +67,19 @@
 ; functions for boolean "and", "or", and "not"
 (define mb-and
   (lambda (l state)
-    (if (and (eq? (M_boolean(operand1 l) state) 'true) (eq? (M_boolean(operand2 l) state) 'true))
+    (if (and (eq? (M_value(operand1 l) state) 'true) (eq? (M_value(operand2 l) state) 'true))
         'true
         'false)))
 
 (define mb-or
   (lambda (l state)
-    (if (or (eq? (M_boolean(operand1 l) state) 'true) (eq? (M_boolean(operand2 l) state) 'true))
+    (if (or (eq? (M_value(operand1 l) state) 'true) (eq? (M_value(operand2 l) state) 'true))
         'true
         'false)))
 
 (define mb-not
   (lambda (l state)
-    (if (eq? (M_boolean(operand1 l) state) 'true)
+    (if (eq? (M_value(operand1 l) state) 'true)
         'false
         'true)))
 

--- a/evaluate.scm
+++ b/evaluate.scm
@@ -1,9 +1,0 @@
-(define next-statement car)
-(define rest-statements cdr)
-
-(define evaluate
-  (lambda (program state)
-    (cond
-      ((null? program) state)
-      (else (evaluate (rest-statements program) (M_state next-statement state))))))
-      

--- a/interpreter.scm
+++ b/interpreter.scm
@@ -6,11 +6,9 @@
 (define program (parser "tests/test1"))
 
 ; the empty state has one value - "return" - which is set to null
-(define empty-state
-  (lambda ()
-    '((return) (()))))
+(define empty-state '((return) (())))
 
 (define sample-state '((a b c x y z q r return) (1 2 3 4 5 6 #t #f '())))
 
 ; output the return value of the program
-(state-get 'return (evaluate program (empty-state)))
+(state-get 'return (evaluate program empty-state))

--- a/interpreter.scm
+++ b/interpreter.scm
@@ -1,14 +1,19 @@
 (load "simpleParser.scm")
-(load "state.scm")
 (load "M_state.scm")
-(load "evaluate.scm")
 
-(define program (parser "tests/test1"))
+(define empty-state '(()()))
 
-; the empty state has one value - "return" - which is set to null
-(define empty-state '((return) (())))
+(define interpret
+  (lambda (filename)
+    (evaluate (parser filename) empty-state)))
 
-(define sample-state '((a b c x y z q r return) (1 2 3 4 5 6 #t #f '())))
+(define evaluate
+  (lambda (program state)
+    (cond
+      ((state-has-return? state) (state-get 'return state))
+      ((null? program) 'null) ; an empty program (the ultimate evaluation of a program without a return statement) returns 'null
+      (else (evaluate (rest-statements program) (M_state (next-statement program) state))))))
 
-; output the return value of the program
-(state-get 'return (evaluate program empty-state))
+; macros for program evaluation
+(define next-statement car)
+(define rest-statements cdr)

--- a/state.scm
+++ b/state.scm
@@ -63,7 +63,9 @@
 ; creates a name-value pair in a given state that represents the return value of the state
 (define state-add-return
   (lambda (value state)
-    (state-cons (list 'return value) state)))
+    (list
+     (cons 'return (names state))
+     (cons value (vals state)))))
 
 ; whether a given state has a return value
 (define state-has-return?

--- a/state.scm
+++ b/state.scm
@@ -56,5 +56,19 @@
   (lambda (name state)
     (cond
       ((null? (names state)) (list (list name) (list null)))
+      ((eq? name 'return) (error "'return cannot be used as a variable name"))
       ((eq? name (car (names state))) (error 'declared "Variable is already declared"))
       (else (state-cons (state-car state) (state-declare name (state-cdr state)))))))
+
+; creates a name-value pair in a given state that represents the return value of the state
+(define state-add-return
+  (lambda (value state)
+    (state-cons (list 'return value) state)))
+
+; whether a given state has a return value
+(define state-has-return?
+  (lambda (state)
+    (cond
+      ((null? (names state)) #f)
+      ((eq? 'return (car (names state))) #t)
+      (else (state-has-return? (state-cdr state))))))


### PR DESCRIPTION
`interpret` implemented. To run it on a file, call `(interpret "filename")`.

`M_state` implemented. It can handle statements of the following types:
- declaration (e.g. `(var x)`, `(var i 0)`)
- assignment (e.g. `(= x 5)`)
- `if` statements
- `while` statements
- `return` statements

Finally, the scope of `M_value` was modified. It now handles the following:
- immediate values (e.g. `true`, `5`)
- variables (e.g. `x`)
- expressions (e.g. `(+ 3 x)`)
- assignments (e.g. `(= x 2)`, which returns `2`)
- declarations with assignment (e.g. `(var i 0)`, which returns `0`)
- comparisons (e.g. `(== x 5)`, `(< 3 2)`)
- logical operations (e.g. `(&& x true)`, `(! y)`)
